### PR TITLE
added -L40693{GLFW_STATIC_LIBRARY_DIRS} to Examples/CMakeLists.txt

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(HelloWorld HelloWorld.c ../ExampleAndTestDeps/GL/gl3w.c)
 set_target_properties(HelloWorld PROPERTIES COMPILE_FLAGS "-std=c89 -pedantic")
-target_link_libraries(HelloWorld ${TARPDEPS} ${GLFW_STATIC_LIBRARIES})
+target_link_libraries(HelloWorld ${TARPDEPS} -L${GLFW_STATIC_LIBRARY_DIRS} ${GLFW_STATIC_LIBRARIES})
 
 add_executable(Playground Playground.c ../ExampleAndTestDeps/GL/gl3w.c)
-target_link_libraries(Playground ${TARPDEPS} ${GLFW_STATIC_LIBRARIES})
+target_link_libraries(Playground ${TARPDEPS} -L${GLFW_STATIC_LIBRARY_DIRS} ${GLFW_STATIC_LIBRARIES})


### PR DESCRIPTION
Hi,

this was needed so the linking command could find the glfw3 libraries

Cheers,

stéphane