### PR TITLE
Fix issue of duplicated function definitions

### DIFF
--- a/Tarp/Tarp.h
+++ b/Tarp/Tarp.h
@@ -183,11 +183,11 @@ helper to generate a typesafe handle class.
     } _t
 
 #define TARP_HANDLE_FUNCTIONS(_t)                                                                  \
-    tpBool _t##IsValidHandle(_t _val)                                                              \
+    static tpBool _t##IsValidHandle(_t _val)                                                              \
     {                                                                                              \
         return (tpBool)(_val.pointer != NULL);                                                     \
     }                                                                                              \
-    _t _t##InvalidHandle()                                                                         \
+    static _t _t##InvalidHandle()                                                                         \
     {                                                                                              \
         _t ret = { NULL };                                                                         \
         return ret;                                                                                \


### PR DESCRIPTION
When Tarp.h is included in multiple C source files, the linker would complain about function redefinitions. Making the functions in question static resolves the issue.